### PR TITLE
Add string and blob support

### DIFF
--- a/addons/godOSC/scripts/OSCServer.gd
+++ b/addons/godOSC/scripts/OSCServer.gd
@@ -17,33 +17,21 @@ var incoming_messages := {}
 ## amount of recieved messages * average message rate / 60.
 @export var parse_rate = 10
 var server = UDPServer.new()
-var peers = []
-
+var peers: Array[PacketPeerUDP] = []
 
 func _ready():
 	server.listen(port)
 
-
 ## Sets the port for the server to listen on. Can only listen to one port at a time.
 func listen(new_port):
-	if new_port == port:
-		server.listen(port)
-	else:
-		server.listen(new_port)
-	
-
+	port = new_port
+	server.listen(port)
 
 func _process(_delta):
-	server.poll() 
-	
+	server.poll()
 	if server.is_connection_available():
 		var peer: PacketPeerUDP = server.take_connection()
-		var packet = peer.get_packet()
 		print("Accepted peer: %s:%s" % [peer.get_packet_ip(), peer.get_packet_port()])
-		print("Received data: %s" % [packet.get_string_from_utf8()])
-		
-		# Reply so it knows we received the message.
-		peer.put_packet(packet)
 		# Keep a reference so we can keep contacting the remote peer.
 		peers.append(peer)
 	
@@ -52,60 +40,39 @@ func _process(_delta):
 
 ## Parses an OSC packet. This is not intended to be called directly outside of the OSCServer
 func parse():
-	for i in range(0, peers.size()):
-		var packet = peers[i].get_packet()
-		
-		for l in range(parse_rate - 1):
-			var new_pack = peers[i].get_packet()
-			parse_message(new_pack)
-		
-		var address = packet.get_string_from_ascii()
-		var comma = packet.find(44)
-		var flags = []
-		var args = (packet.slice(comma, packet.size()).size()/4.0) - 1
-		var vals = []
-		
-		for j in packet.slice(comma+1, comma + 1 + args):
-			if j != 0:
-				flags.append(j)
-		
-		packet.reverse()
-		flags.reverse()
-		
-		for j in range(len(flags)):
-			match flags[j]:
-				105:
-					vals.append(packet.decode_s32(j*4))
-				102:
-					vals.append(packet.decode_float(j*4))
-		
-		vals.reverse()
-		if len(vals) > 0:
-			incoming_messages[address] = vals
+	for peer in peers:
+		for l in range(peer.get_available_packet_count()):
+			var packet = peer.get_packet()
+			parse_message(packet)
 
-
-
-func parse_message(packet):
-	var address = packet.get_string_from_ascii()
-	var comma = packet.find(44)
-	var flags = []
-	var args = (packet.slice(comma, packet.size()).size()/4.0) - 1
-	
+func parse_message(packet: PackedByteArray):
+	var comma_index = packet.find(44)
+	var address = packet.slice(0, comma_index).get_string_from_ascii()
+	var args = packet.slice(comma_index, packet.size())
+	var tags = args.get_string_from_ascii()
 	var vals = []
-	for j in packet.slice(comma+1, comma + 1 + args):
-		flags.append(j)
-	
-	packet.reverse()
-	flags.reverse()
-	
-	for j in range(len(flags)):
-		match flags[j]:
-			105:
-				vals.append(packet.decode_s32(j*4))
-			102:
-				vals.append(packet.decode_float(j*4))
-	
-	vals.reverse()
-	if len(vals) > 0:
-		incoming_messages[address] = vals
 
+	args = args.slice(ceili((tags.length() + 1) / 4.0) * 4, args.size())
+	
+	for tag in tags.to_ascii_buffer():
+		match tag:
+			44: #,: comma
+				pass
+			105: #i: int32
+				var val = args.slice(0, 4)
+				val.reverse()
+				vals.append(val.decode_s32(0))
+				args = args.slice(4, args.size())
+			102: #f: float32
+				var val = args.slice(0, 4)
+				val.reverse()
+				vals.append(val.decode_float(0))
+				args = args.slice(4, args.size())
+			115: #s: string
+				var val = args.get_string_from_ascii()
+				vals.append(val)
+				args = args.slice(ceili((val.length() + 1) / 4.0) * 4, args.size())
+			98:  #b: blob
+				vals.append(args)
+	
+	incoming_messages[address] = vals


### PR DESCRIPTION
I'm currently writing an application which requires to communicate to x32/m32 digital mixer. After several failed attempts I've figured out string and blob was not supported by godOSC. So I've implemented them in this PR.

Here is brief summary of changes I made:

# OSCClient
- Added close_socket function which closes socket if opened before
- connect_socket function calls close_socket before connecting to another socket
- Added prepare_message function. So send_message function calls it before sending new packet.
- send_message function not preparing packet itself. It calls prepare_packet for this purpose.
- prepare_packet function now supports string and blob type of osc messages.

# OSCServer
- _process function not getting first packet from buffer itself. Getting packet causes first message was not parsed by parser because of get_packet function removes the packet from peer's buffer.
- parse function now only gets packet from peer and parsing is done by parse_message function.
- parse_message function now supports string and blob type of osc messages.

# Design changes
- I liked the idea of parse_rate but instead of it I've used get_available_packet_count to parse all received packets. If this change bothers you I can revert it or we can change it according to your desire.
- Parsing logic slightly changed due to variable size of string and blob types.

Thanks for your work.