### PR TITLE
Boolean support for OSCServer.gd and OSCClient.gd

### DIFF
--- a/addons/godOSC/scripts/OSCClient.gd
+++ b/addons/godOSC/scripts/OSCClient.gd
@@ -35,6 +35,11 @@ func prepare_message(osc_address : String, args : Array):
 	packet.append(44)
 	for arg in args:
 		match typeof(arg):
+			TYPE_BOOL:
+				if arg:
+					packet.append(84)
+				else:
+					packet.append(70)
 			TYPE_INT:
 				packet.append(105)
 			TYPE_FLOAT:
@@ -51,6 +56,13 @@ func prepare_message(osc_address : String, args : Array):
 	for arg in args:
 		var pack = PackedByteArray()
 		match typeof(arg):
+			TYPE_BOOL:
+				if arg:
+					pack.append_array([1])
+					pack.reverse()
+				else:
+					pack.append_array([0])
+					pack.reverse()
 			TYPE_INT:
 				pack.append_array([0, 0, 0, 0])
 				pack.encode_s32(0, arg)

--- a/addons/godOSC/scripts/OSCServer.gd
+++ b/addons/godOSC/scripts/OSCServer.gd
@@ -64,6 +64,10 @@ func parse_message(packet: PackedByteArray):
 		match tag:
 			44: #,: comma
 				pass
+			70: # Boolean OFF
+				vals.append(false)
+			84: # Boolean ON
+				vals.append(true)
 			105: #i: int32
 				var val = args.slice(0, 4)
 				val.reverse()

--- a/addons/godOSC/scripts/OSCServer.gd
+++ b/addons/godOSC/scripts/OSCServer.gd
@@ -3,6 +3,8 @@ class_name OSCServer
 extends Node
 ## Server for recieving Open Sound Control messages over UDP. 
 
+## Signal emmited when receiving single messages.
+signal OSC_Received(key, val)
 
 ## The port over which to recieve messages
 @export var port = 4646
@@ -88,6 +90,7 @@ func parse_message(packet: PackedByteArray):
 			
 	
 	incoming_messages[address] = vals
+	OSC_Received.emit(address, vals)
 
 
 #Handle and parse incoming bundles


### PR DESCRIPTION
This fork adds support for sending and receiving Boolean data through godOSC's exsisting custom nodes.
Sending Bools works exactly as other exsisting data types, with no work-arounds needed.